### PR TITLE
Upload multiple files.

### DIFF
--- a/UploadStream.UnitTests/StreamFileTests.cs
+++ b/UploadStream.UnitTests/StreamFileTests.cs
@@ -77,6 +77,8 @@ namespace UploadStream.UnitTests {
                 file.Length.Should().Be(0);
                 while (file.OpenReadStream().ReadByte() != -1) ;
                 file.Length.Should().Be(bytes.Length);
+
+                return Task.CompletedTask;
             });
 
             // assert

--- a/UploadStream/ControllerExtensions.cs
+++ b/UploadStream/ControllerExtensions.cs
@@ -13,7 +13,7 @@ namespace UploadStream {
         /// <typeparam name="T"></typeparam>
         /// <param name="func"></param>
         /// <returns>Returns multi-part form fields as the required generic model specified.</returns>
-        public static async Task<T> StreamFiles<T>(this ControllerBase controller, Action<IFormFile> func) where T : class, new() {
+        public static async Task<T> StreamFiles<T>(this ControllerBase controller, Func<IFormFile, Task> func) where T : class, new() {
             var form = await controller.Request.StreamFilesModel(func);
             return await UpdateModel<T>(form, controller);
         }
@@ -22,7 +22,7 @@ namespace UploadStream {
         /// Processes Multi-part HttpRequest streams via the specified delegate, no model required for return
         /// </summary>
         /// <param name="func"></param>
-        public static async Task StreamFiles(this Controller controller, Action<IFormFile> func) {
+        public static async Task StreamFiles(this Controller controller, Func<IFormFile, Task> func) {
             await controller.Request.StreamFilesModel(func);
         }
 


### PR DESCRIPTION
Use async lambda definition in StreamFiles methods.
Ensure stream is seekabke before accessing position property.