### PR TITLE
Populate MultipartFile.Headers so custom headers are accessible

### DIFF
--- a/UploadStream/HttpRequestExtensions.cs
+++ b/UploadStream/HttpRequestExtensions.cs
@@ -40,6 +40,7 @@ namespace UploadStream {
 
                         // process file stream
                         await func(new MultipartFile(fileSection.FileStream, fileSection.Name, fileSection.FileName) {
+                            Headers = new HeaderDictionary(fileSection.Section.Headers),
                             ContentType = fileSection.Section.ContentType,
                             ContentDisposition = fileSection.Section.ContentDisposition
                         });

--- a/UploadStream/UploadStream.csproj
+++ b/UploadStream/UploadStream.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
@@ -12,7 +12,7 @@
         <PackageId>UploadStream</PackageId>
         <Authors>Mark Alford</Authors>
         <Company>ZenistCode</Company>
-        <Version>3.1.1</Version>
+        <VersionPrefix>3.1.2</VersionPrefix>
         <PackageTags>File;Upload</PackageTags>
         <Title>UploadStream - high performance file upload streaming for dotnet</Title>
         <Description>


### PR DESCRIPTION
Currently Content-Type and Content-Disposition are the only multipart section headers that are transferred from the parsed FileMultipartSection over to the constructed MultipartFile wrapper that is passed to the StreamFiles delegate.
This change populates all of the headers from the source Headers dictionary into the MultipartFile.Headers wrapper.